### PR TITLE
Harden auth context initialization and align imports

### DIFF
--- a/app/interface/src/App.jsx
+++ b/app/interface/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, NavLink, useNavigate, Navigate } from 'react-router-dom';
-import { useAuth } from './context/AuthContext';
+import { useAuth } from '@/context/AuthContext';
 
 import HomePage from './pages/Home/home';
 import LoginPage from './pages/LoginPage/LoginPage';

--- a/app/interface/src/context/AuthContext.jsx
+++ b/app/interface/src/context/AuthContext.jsx
@@ -1,87 +1,114 @@
-import React, { createContext, useState, useContext, useEffect, useMemo, useCallback} from 'react';
+import {
+  createContext,
+  useState,
+  useContext,
+  useEffect,
+  useMemo,
+  useCallback,
+} from 'react';
 import { jwtDecode } from 'jwt-decode';
 import api from '../api';
 
 const AuthContext = createContext(null);
 
 const getStoredToken = () => {
-    if (typeof window === 'undefined') {
-        return null;
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem('authToken');
+  } catch (error) {
+    console.warn('Não foi possível acessar o localStorage', error);
+    return null;
+  }
+};
+
+const persistToken = (token) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    if (token) {
+      window.localStorage.setItem('authToken', token);
+    } else {
+      window.localStorage.removeItem('authToken');
     }
+  } catch (error) {
+    console.warn('Falha ao persistir token no localStorage', error);
+  }
+};
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(getStoredToken);
+  const [user, setUser] = useState(null);
+
+  const logout = useCallback(() => {
+    persistToken(null);
+    setToken(null);
+    setUser(null);
+    delete api.defaults.headers.common.Authorization;
+  }, []);
+
+  const login = useCallback(
+    (newToken) => {
+      if (!newToken) {
+        logout();
+        return;
+      }
+
+      persistToken(newToken);
+      setToken(newToken);
+    },
+    [logout],
+  );
+
+  useEffect(() => {
+    if (!token) {
+      setUser(null);
+      delete api.defaults.headers.common.Authorization;
+      return;
+    }
+
     try {
-        return window.localStorage.getItem('authToken');
+      const decoded = jwtDecode(token);
+
+      if (decoded?.exp && decoded.exp * 1000 > Date.now()) {
+        setUser({ username: decoded.sub });
+        api.defaults.headers.common.Authorization = `Bearer ${token}`;
+      } else {
+        logout();
+      }
     } catch (error) {
-        console.warn('Não foi possível acessar o localStorage', error);
-        return null;
+      console.error('Token inválido:', error);
+      logout();
     }
+  }, [token, logout]);
+
+  const value = useMemo(
+    () => ({
+      user,
+      token,
+      login,
+      logout,
+    }),
+    [user, token, login, logout],
+  );
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
 };
 
-    const persistToken = (token) => {
-        if (typeof window === 'undefined') {
-            return;
-        }
-        try {
-            if (token) {
-                window.localStorage.setItem('authToken', token);
-            } else {
-                window.localStorage.removeItem('authToken')
-            }
-        } catch (error) {
-            console.warn('Falha ao persistir token no localStorage', error)
+export const useAuth = () => {
+  const context = useContext(AuthContext);
 
-        }
-    };
+  if (!context) {
+    throw new Error('useAuth deve ser utilizado dentro de um AuthProvider');
+  }
 
-    export const AuthProvider = ({ children }) => {
-        const [token, setToken] = useState(getStoredToken);
-        const [user, setUser] = useState(null)
-
-    const logout = useCallback (() => {
-        persistToken(null);
-        setToken(null);
-        setUser(null);
-        delete api.defaults.headers.common['Authorization'];
-    }, []);
-
-            const login = useCallback((newToken) => {
-        persistToken(newToken);
-        setToken(newToken);
-    }, []);
-
-    useEffect(() => {
-        if (!token) {
-            setUser(null);
-            delete api.defaults.headers.common['Authorization'];
-            return;
-        }
-
-        try {
-            const decoded = jwtDecode(token);
-
-            if (decoded.exp * 1000 > Date.now()) {
-                setUser({ username: decoded.sub });
-                api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-            } else {
-                logout();
-            }
-        } catch (error) {
-            console.error('Token inválido:', error);
-            logout();
-        }
-    }, [token, logout]);
-
-    const value = useMemo(() => ({
-        user,
-        token,
-        login,
-        logout,
-    }), [user, token, login, logout]);
-
-    return (
-        <AuthContext.Provider value={{ value }}>
-            {children}
-        </AuthContext.Provider>
-    );
+  return context;
 };
-
-export const useAuth = () => useContext(AuthContext);

--- a/app/interface/src/main.jsx
+++ b/app/interface/src/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from './App.jsx';
-import { AuthProvider } from './context/AuthContext';
+import { AuthProvider } from '@/context/AuthContext';
 import './App.css';
 import './index.css';
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import interfaceConfig from './app/interface/eslint.config.js';
+
+export default interfaceConfig;


### PR DESCRIPTION
## Summary
- refactor the auth context to safely persist tokens, clear invalid sessions and surface a guard when `useAuth` is used without a provider
- update the app shell to import the auth context through the shared alias so every consumer receives the same instance
- expose the interface ESLint configuration at the repository root so tooling like `npm run lint` can locate it

## Testing
- npm run build
- npm run lint *(fails: numerous pre-existing lint violations around unused React imports and missing prop-types in legacy files)*

------
https://chatgpt.com/codex/tasks/task_b_68cace3a42f483309f1482da2a82a64d